### PR TITLE
Catch keywords that don't play nicely with OpenStruct

### DIFF
--- a/lib/rails_config/options.rb
+++ b/lib/rails_config/options.rb
@@ -83,14 +83,24 @@ module RailsConfig
       self
     end
 
+    # Some keywords that don't play nicely with OpenStruct
+    SETTINGS_RESERVED_NAMES = %w{select collect system}
+
     # An alternative mechanism for property access.
     # This let's you do foo['bar'] along with foo.bar.
     def [](param)
+      return super if SETTINGS_RESERVED_NAMES.include?(param)
       send("#{param}")
     end
 
     def []=(param, value)
       send("#{param}=", value)
+    end
+
+    SETTINGS_RESERVED_NAMES.each do |name|
+      define_method name do
+        self[name]
+      end
     end
 
     protected


### PR DESCRIPTION
There might be a better way to do this, but this worked when I opened up the gem in my project.