### PR TITLE
Allows to load RailsConfig manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ Add this to your `Gemfile`:
 gem "rails_config"
 ```
 
+If you want to use Settings before rails application initialization process you can load RailsConfig railtie manually:
+
+```ruby
+module Appname
+  class Application < Rails::Application
+
+    Bundler.require(*Rails.groups)
+    RailsConfig::Integration::Rails::Railtie.preload
+
+    ...
+
+    config.time_zone = Settings.time_zone
+
+    ...
+
+   end
+end
+```
+
 ## Installing on Padrino
 
 Add this to your `Gemfile`:

--- a/lib/rails_config/integration/rails.rb
+++ b/lib/rails_config/integration/rails.rb
@@ -8,7 +8,9 @@ module RailsConfig
             Dir[File.join(File.dirname(__FILE__),'../tasks/*.rake')].each { |f| load f }
           end
 
-          ActiveSupport.on_load :before_configuration, :yield => true do
+          config.before_configuration { preload }
+
+          def preload
             # Manually load the custom initializer before everything else
             initializer = ::Rails.root.join("config", "initializers", "rails_config.rb")
             require initializer if File.exist?(initializer)


### PR DESCRIPTION
Allows to load RailsConfig manually and even before app configuration process (e.g. inside config/application.rb):

```ruby
module Appname
  class Application < Rails::Application

    Bundler.require(*Rails.groups)
    RailsConfig::Integration::Rails::Railtie.preload

    ...

    config.time_zone = Settings.time_zone

    ...

   end
end
```

refers to #106 